### PR TITLE
Polish of UI logic and DB interface improvement

### DIFF
--- a/src/DBConnect.cs
+++ b/src/DBConnect.cs
@@ -16,7 +16,9 @@ namespace Evemu_DB_Editor.src
     static class DBConnect
     {
         private static MySqlConnection connection;
-        public static bool isConnectionOpen = false;
+        private static bool isConnectionOpen = false;
+
+        public static bool isConnected() { return isConnectionOpen; }
 
         //open connection to database
         public static void OpenConnection()
@@ -110,7 +112,7 @@ namespace Evemu_DB_Editor.src
         }
 
         // Simple Query: Handles INSERT, UPDATE, DELETE, ALTER and others i may have forgotten...
-        public static bool SQuery(string query)
+        public static int SQuery(string query)
         {
             try
             {
@@ -120,19 +122,18 @@ namespace Evemu_DB_Editor.src
                     MySqlCommand cmd = new MySqlCommand(query, connection);
 
                     //Execute command
-                    cmd.ExecuteNonQuery();
-                    return true;
+                    return cmd.ExecuteNonQuery();
                 }
                 else
                 {
                     MessageBox.Show("Please connect to DB first");
-                    return false;
+                    return -1;
                 }
             }
             catch (Exception e)
             {
                 MessageBox.Show("Exception: " + e.Message);
-                return false;
+                return -1;
             }
         }
 

--- a/src/GUI/mainF.cs
+++ b/src/GUI/mainF.cs
@@ -68,6 +68,7 @@ namespace Evemu_DB_Editor
 
         private void main_Load(object sender, EventArgs e)
         {
+            disconnectBtn_Click(null, null);
             connection = ("server=" + hostTextBox.Text + ";username=" + usernameTxtBox.Text + ";password=" + passwordTxtBox.Text + ";port=" + portTxtBox.Text + ";database=" + dbNameTxtBox.Text);
             if (System.IO.File.Exists(Environment.GetFolderPath(System.Environment.SpecialFolder.ApplicationData) + "\\EvEMU DB\\EvemuDBEditor.ini"))
             {
@@ -114,6 +115,12 @@ namespace Evemu_DB_Editor
                 this.Refresh();
             }
         }
+
+        private void showNotConnected() {
+            MessageBox.Show("Please connect to the database!", "Not conneced!", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            accountTab.SelectedIndex = 0;
+        }
+
         #endregion
 
         #region File Tab
@@ -165,7 +172,7 @@ namespace Evemu_DB_Editor
             else
             {
                 DBConnect.OpenConnection(hostTextBox.Text, usernameTxtBox.Text, passwordTxtBox.Text, dbNameTxtBox.Text);
-                if (DBConnect.isConnectionOpen)
+                if (DBConnect.isConnected() )
                 {
                     connectionStatusLbl.Text = "Connected";
                     connectionStatusLbl.ForeColor = Color.Green;
@@ -173,6 +180,15 @@ namespace Evemu_DB_Editor
                     connectionStatusToolTip.ForeColor = Color.Green;
                     connectBtn.Enabled = false;
                     disconnectBtn.Enabled = true;
+
+                    ((Control)tabAccount).Enabled = true;
+                    ((Control)tabInsure).Enabled = true;
+                    ((Control)tabItemEditor).Enabled = true;
+                    ((Control)raceTab).Enabled = true;
+                    ((Control)marketTab).Enabled = true;
+                    ((Control)oreTab).Enabled = true;
+                    ((Control)tabPage1).Enabled = true;
+
                 }
                 else
                 {
@@ -184,13 +200,23 @@ namespace Evemu_DB_Editor
 
         private void disconnectBtn_Click(object sender, EventArgs e)
         {
-            DBConnect.CloseConnection();
-            connectionStatusLbl.Text = "Disconnected";
-            connectionStatusLbl.ForeColor = Color.Black;
-            connectionStatusToolTip.Text = "Disconnected from DB";
-            connectionStatusToolTip.ForeColor = Color.Black;
-            connectBtn.Enabled = true;
-            disconnectBtn.Enabled = false;
+            if(DBConnect.isConnected() ) {
+                DBConnect.CloseConnection();
+                connectionStatusLbl.Text = "Disconnected";
+                connectionStatusLbl.ForeColor = Color.Black;
+                connectionStatusToolTip.Text = "Disconnected from DB";
+                connectionStatusToolTip.ForeColor = Color.Black;
+                connectBtn.Enabled = true;
+                disconnectBtn.Enabled = false;
+            }
+
+            ((Control)tabAccount).Enabled = false;
+            ((Control)tabInsure).Enabled = false;
+            ((Control)tabItemEditor).Enabled = false;
+            ((Control)raceTab).Enabled = false;
+            ((Control)marketTab).Enabled = false;
+            ((Control)oreTab).Enabled = false;
+            ((Control)tabPage1).Enabled = false;
         }
 
         private void runSQLFileBtn_Click(object sender, EventArgs e)
@@ -294,7 +320,7 @@ namespace Evemu_DB_Editor
 
                 query = "INSERT INTO account (accountName, password, role) VALUES ('" + newUsername.Text + "', '" + newPassword.Text + "', '" + acctrole + "')";
 
-                if (DBConnect.SQuery(query) == true)
+                if (DBConnect.SQuery(query) == 1)
                 {
                     newUsername.Clear();
                     newPassword.Clear();
@@ -444,6 +470,10 @@ namespace Evemu_DB_Editor
 
         private void tabItemEditor_Enter(object sender, EventArgs e)
         {
+            if(!DBConnect.isConnected() ) {
+                showNotConnected();
+                return;
+            }
             foreach (DataRow record in DBConnect.AQuery("SELECT CategoryName from invCategories").Rows)
             {
                 CategoryDropdown.Items.Add(record[0]);
@@ -580,6 +610,10 @@ namespace Evemu_DB_Editor
         #region Race
         private void raceTab_Enter(object sender, EventArgs e)
         {
+            if(!DBConnect.isConnected() ) {
+                showNotConnected();
+                return;
+            }
             raceDropdown.Items.Clear();
             foreach (DataRow record in DBConnect.AQuery("SELECT raceName from chrRaces").Rows)
             {
@@ -767,6 +801,11 @@ namespace Evemu_DB_Editor
         private void marketTab_Enter(object sender, EventArgs e)
         {
             //marketRaces.Items.Add("*");
+            if(!DBConnect.isConnected() ) {
+                showNotConnected();
+                return;
+            }
+
             marketRacesTxtBox.Items.Clear();
             foreach (DataRow record in DBConnect.AQuery("SELECT raceName, raceID FROM chrRaces ORDER BY raceName").Rows)
             {
@@ -975,6 +1014,10 @@ namespace Evemu_DB_Editor
         #region ORE
         private void oreTab_Enter(object sender, EventArgs e)
         {
+            if(!DBConnect.isConnected() ) {
+                showNotConnected();
+                return;
+            }
             SELECTOre.Items.Clear();
             foreach (DataRow record in DBConnect.AQuery("SELECT typeName FROM invTypes WHERE groupID IN (SELECT groupid FROM invGroups WHERE categoryid = 25)").Rows)
             {
@@ -1061,6 +1104,10 @@ namespace Evemu_DB_Editor
 
         private void tabPage1_Enter(object sender, EventArgs e)
         {
+            if(!DBConnect.isConnected() ) {
+                showNotConnected();
+                return;
+            }
             marketGroupsTree.Nodes.Clear();
             foreach (DataRow record in DBConnect.AQuery("SELECT marketGroupID, marketGroupName FROM invMarketGroups WHERE parentGroupID IS NULL").Rows)
             {


### PR DESCRIPTION
- `DBConnect.SQuery()` returns int (a number of rows affected or -1 if there was an error) TODO: It should throw an exception actually.
- `bool DBConnect.isConnected()` replaces `DBConnect.isConnectionOpen` field for public interface
- All tabs that require sql are disabled until user connects to sql.
- Most of the tabs do not allow to be switched to if there is no sql connection - and they use one method to do this.
